### PR TITLE
Configure renovate to only handle security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackagePatterns": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
Renovate generates a lot of noise with its default configuration because it opens a dependency update PR for every single major, minor, or patch version of every dependency.

This updates the renovate configuration to only handle security updates so that we can reduce PR noise and be more intentional about dependency updates.  Configuration here was taken from: https://github.com/renovatebot/renovate/discussions/15490